### PR TITLE
Idempotent scopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem "json_api_client", path: "../json_api_client"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "json_api_client", path: "../json_api_client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 PATH
+  remote: ../json_api_client
+  specs:
+    json_api_client (1.5.3)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (~> 0.15, >= 0.15.2)
+      faraday_middleware (~> 0.9)
+
+PATH
   remote: .
   specs:
     json_api_model (0.3.2)
@@ -29,12 +39,6 @@ GEM
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    json_api_client (1.5.3)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      addressable (~> 2.2)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.9)
     minitest (5.11.3)
     multipart-post (2.0.0)
     public_suffix (3.0.2)
@@ -58,6 +62,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
+  json_api_client!
   json_api_model!
   minitest (~> 5.0)
   rake (~> 10.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 PATH
-  remote: ../json_api_client
-  specs:
-    json_api_client (1.5.3)
-      activemodel (>= 3.2.0)
-      activesupport (>= 3.2.0)
-      addressable (~> 2.2)
-      faraday (~> 0.15, >= 0.15.2)
-      faraday_middleware (~> 0.9)
-
-PATH
   remote: .
   specs:
     json_api_model (0.3.2)
@@ -39,9 +29,15 @@ GEM
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
+    json_api_client (1.6.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (~> 0.15, >= 0.15.2)
+      faraday_middleware (~> 0.9)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    public_suffix (3.0.2)
+    public_suffix (3.0.3)
     rake (10.5.0)
     safe_yaml (1.0.4)
     simplecov (0.16.1)
@@ -62,7 +58,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.16)
-  json_api_client!
   json_api_model!
   minitest (~> 5.0)
   rake (~> 10.0)

--- a/lib/json_api_model/associations/base.rb
+++ b/lib/json_api_model/associations/base.rb
@@ -13,7 +13,6 @@ module JsonApiModel
       end
 
       def fetch( instance )
-        puts "#{klass}.#{action}( #{query(instance)})"
         process klass.send( action, query( instance ) )
       end
 

--- a/lib/json_api_model/associations/base.rb
+++ b/lib/json_api_model/associations/base.rb
@@ -13,6 +13,7 @@ module JsonApiModel
       end
 
       def fetch( instance )
+        puts "#{klass}.#{action}( #{query(instance)})"
         process klass.send( action, query( instance ) )
       end
 

--- a/lib/json_api_model/associations/belongs_to.rb
+++ b/lib/json_api_model/associations/belongs_to.rb
@@ -13,7 +13,7 @@ module JsonApiModel
 
       def query( instance )
         if instance.has_relationship_ids? name
-          { id: instance.relationship_ids( name ) }
+          instance.relationship_ids( name ).first
         else
           instance.send key
         end

--- a/lib/json_api_model/scope.rb
+++ b/lib/json_api_model/scope.rb
@@ -42,20 +42,24 @@ module JsonApiModel
       end
     end
 
-    def params
-      @client_scope.params
-    end
-
     def method_missing( m, *args, &block )
       if @client_scope.respond_to? m
-        @client_scope.send m, *args, &block
-        self
+        _new_scope @client_scope.send( m, *args, &block )
       else
         all.send m, *args, &block
       end
     end
 
+    attr_accessor :client_scope
+    delegate :params, to: :client_scope
+
     private
+
+    def _new_scope( client_scope )
+      self.class.new( @model_class ).tap do |scope|
+        scope.client_scope = client_scope
+      end
+    end
 
     def cached?
       @cache.has_key? keyify

--- a/test/associatable_test.rb
+++ b/test/associatable_test.rb
@@ -45,7 +45,7 @@ class AssociatableTest < Minitest::Test
                                   },
                             meta: { record_count: 1, page_count: 1 } }.to_json )
 
-    stub_request(:get, "http://example.com/orgs?filter[id][0]=1")
+    stub_request(:get, "http://example.com/orgs/1")
         .to_return( status: 200,
                     headers: { content_type: 'application/vnd.api+json' },
                     body: { data: [ { type: :orgs,

--- a/test/associatable_test.rb
+++ b/test/associatable_test.rb
@@ -210,6 +210,33 @@ class AssociatableTest < Minitest::Test
     assert_requested stub, times: 1
   end
 
+  def test_first_doesnt_modify_scope
+    all_stub = stub_request( :get, "http://example.com/users?filter[name]=Greg" )
+            .to_return( headers: { content_type: "application/vnd.api+json" },
+                        body: { data: { type: :users,
+                                    id: 1,
+                                    attributes: { name: "Greg" },
+                                    links: { self: ""}
+                                  },
+                                meta: { record_count: 1, page_count: 1 } }.to_json )
+    first_stub = stub_request( :get, "http://example.com/users?filter[name]=Greg&page[page]=1&page[per_page]=1" )
+            .to_return( headers: { content_type: "application/vnd.api+json" },
+                        body: { data: { type: :users,
+                                    id: 1,
+                                    attributes: { name: "Greg" },
+                                    links: { self: ""}
+                                  },
+                                meta: { record_count: 1, page_count: 1 } }.to_json )
+    scope = Example::User.where( name: "Greg" )
+
+    scope.first
+    scope.all
+
+    assert_requested all_stub, times: 1
+    assert_requested first_stub, times: 1
+
+  end
+
   def test_object_association_raises
     assert_raises do
       Example::User.belongs_to :object

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -107,10 +107,10 @@ class ModelTest < Minitest::Test
   def test_method_missings_raise_helpful_errors
     user = Example::User.new
     exception = assert_raises NoMethodError do
-      user.id
+      user.not_an_id
     end
 
-    assert_equal "No method `id' found in #{user} or #{user.client}", exception.message
+    assert_equal "No method `not_an_id' found in #{user} or #{user.client}", exception.message
 
     exception = assert_raises NoMethodError do
       Example::User.not_a_method


### PR DESCRIPTION
fixing scope modification issue where `existing.scope` modified with a `where` clause would be side-effected internally. The core issue was in [`JsonApiClient`](https://github.com/JsonApiClient/json_api_client/)([#293](https://github.com/JsonApiClient/json_api_client/pull/293)), but this wraps the fix correctly

```ruby
scope = Example::User.where( name: "Greg" )

scope.all
# => [<Example::User id: 1>, <Example::User id: 2>, ...]

scope.fist
# => <Examnple::User id: 1>

# first modified the scope to only return the first item because the pagination was changed inside the scope
scope.all
# => [<Example::User id: 1>]
```